### PR TITLE
ci: pin external GitHub Actions

### DIFF
--- a/.github/workflows/fork-tests.yml
+++ b/.github/workflows/fork-tests.yml
@@ -13,13 +13,13 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
         with:
           submodules: recursive
       - run: yarn install
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d
         with:
           version: nightly
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,12 +10,12 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
         with:
           submodules: recursive
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d
         with:
           version: nightly
 

--- a/.github/workflows/non-via-ir-compilation.yml
+++ b/.github/workflows/non-via-ir-compilation.yml
@@ -10,13 +10,13 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
         with:
           submodules: recursive
       - run: yarn install
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d
         with:
           version: nightly
 


### PR DESCRIPTION
Pins third-party GitHub Actions `uses:` references to full commit SHAs.

Context: RFC-043 GitHub organization security hardening.

This PR does not change GitHub org settings, branch protection, or workflow permissions.

Pinned references:
- `.github/workflows/fork-tests.yml:16` `actions/checkout@v3` -> `actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744`
- `.github/workflows/fork-tests.yml:22` `foundry-rs/foundry-toolchain@v1` -> `foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d`
- `.github/workflows/lint.yml:13` `actions/checkout@v3` -> `actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744`
- `.github/workflows/lint.yml:18` `foundry-rs/foundry-toolchain@v1` -> `foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d`
- `.github/workflows/non-via-ir-compilation.yml:13` `actions/checkout@v3` -> `actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744`
- `.github/workflows/non-via-ir-compilation.yml:19` `foundry-rs/foundry-toolchain@v1` -> `foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d`